### PR TITLE
svg viewport awareness when positioning form

### DIFF
--- a/example.html
+++ b/example.html
@@ -41,6 +41,10 @@
         padding: 0 1em;
         width: max-content;
       }
+
+      .outside-viewport {
+        border: dotted black 1px;
+      }
     </style>
   </head>
 
@@ -131,6 +135,49 @@
                   }
                 }}>
                   <p>No problem!</p>
+                </ZUITriggeredModalForm>
+              </svg>
+            </p>
+
+            <p>
+              In an SVG element, partially outside viewport:{' '}
+              <br/>
+              <svg className="outside-viewport" width="100" height="100" viewBox="0 0 100 100" style={{
+                verticalAlign: 'middle'
+              }}>
+                <ZUITriggeredModalForm side="bottom" triggerTag="g" trigger={
+                  <line 
+                    x1="30" 
+                    y1="70" 
+                    x2="300" 
+                    y2="70" 
+                    stroke="red"
+                    strokeLinecap="round"
+                    strokeWidth="4" 
+                  />
+                } triggerProps={{
+                  style: {
+                    cursor: 'pointer'
+                  }
+                }}>
+                  <p>No problem!</p>
+                </ZUITriggeredModalForm>
+                <ZUITriggeredModalForm side="right" triggerTag="g" trigger={
+                  <rect 
+                    x="-20"
+                    y="-20"
+                    width="50" 
+                    height="60" 
+                    strokeWidth="3"
+                    stroke="rgb(0,0,0)"
+                    fill="transparent"
+                   />
+                } triggerProps={{
+                  style: {
+                    cursor: 'pointer'
+                  }
+                }}>
+                  <p>This is a rectangle!</p>
                 </ZUITriggeredModalForm>
               </svg>
             </p>

--- a/example.html
+++ b/example.html
@@ -145,40 +145,28 @@
               <svg className="outside-viewport" width="100" height="100" viewBox="0 0 100 100" style={{
                 verticalAlign: 'middle'
               }}>
-                <ZUITriggeredModalForm side="bottom" triggerTag="g" trigger={
-                  <line 
-                    x1="30" 
-                    y1="70" 
-                    x2="300" 
-                    y2="70" 
-                    stroke="red"
-                    strokeLinecap="round"
-                    strokeWidth="4" 
-                  />
-                } triggerProps={{
-                  style: {
-                    cursor: 'pointer'
-                  }
-                }}>
-                  <p>No problem!</p>
-                </ZUITriggeredModalForm>
-                <ZUITriggeredModalForm side="right" triggerTag="g" trigger={
-                  <rect 
-                    x="-20"
-                    y="-20"
-                    width="50" 
-                    height="60" 
-                    strokeWidth="3"
-                    stroke="rgb(0,0,0)"
-                    fill="transparent"
-                   />
-                } triggerProps={{
-                  style: {
-                    cursor: 'pointer'
-                  }
-                }}>
-                  <p>This is a rectangle!</p>
-                </ZUITriggeredModalForm>
+                <g>
+                  <ZUITriggeredModalForm side="bottom" triggerTag="g" trigger={
+                    <line x1="30" y1="70" x2="300" y2="70" stroke="red" strokeLinecap="round" strokeWidth="4" />
+                  } triggerProps={{
+                    style: {
+                      cursor: 'pointer'
+                    }
+                  }}>
+                    <p>No problem!</p>
+                  </ZUITriggeredModalForm>
+                </g>
+                <g>
+                  <ZUITriggeredModalForm side="right" triggerTag="g" trigger={
+                    <rect x="-20" y="-20" width="50" height="60" strokeWidth="3" stroke="rgb(0,0,0)" fill="transparent" />
+                  } triggerProps={{
+                    style: {
+                      cursor: 'pointer'
+                    }
+                  }}>
+                    <p>This is a rectangle!</p>
+                  </ZUITriggeredModalForm>
+                </g>
               </svg>
             </p>
 

--- a/sticky.js
+++ b/sticky.js
@@ -66,17 +66,19 @@
       var anchorRect = this.getRectWithMargin(anchor);
       var anchorParent = anchor.parentElement;
 
-      var current_node = anchor
-      while(current_node !== document.body && getComputedStyle(current_node).overflow !== 'hidden'){
-        current_node = current_node.parentNode;
+      var anchorClipParent = anchor;
+      while(anchorClipParent !== document.body && getComputedStyle(anchorClipParent).overflow !== 'hidden') {
+        anchorClipParent = anchorClipParent.parentNode;
       }
-      var viewport = current_node.getBoundingClientRect();
+
+      var clipViewport = anchorClipParent.getBoundingClientRect();
+      var visibleAnchorRect = this.anchorInsideViewport(anchorRect, clipViewport);
 
       var form = this.refs.form;
       form.style.left = '';
       form.style.top = '';
       var formRect = this.getRectWithMargin(form);
-      var formPosition = this.getPosition[props.side].call(this, formRect, anchorRect, viewport);
+      var formPosition = this.getPosition[props.side].call(this, formRect, visibleAnchorRect);
       form.style.left = pageXOffset + formPosition.left + 'px';
       form.style.top = pageYOffset + formPosition.top + 'px';
 
@@ -84,7 +86,7 @@
       pointer.style.left = '';
       pointer.style.top = '';
       var pointerRect = this.getRectWithMargin(pointer);
-      var pointerPosition = this.getPosition[props.side].call(this, pointerRect, anchorRect, viewport);
+      var pointerPosition = this.getPosition[props.side].call(this, pointerRect, visibleAnchorRect);
       pointer.style.left = pageXOffset + pointerPosition.left + 'px';
       pointer.style.top = pageYOffset + pointerPosition.top + 'px';
     },
@@ -125,49 +127,47 @@
       } else {
         visibleAnchor.bottom = anchorRect.top + anchorRect.height
       }
-      
+
       visibleAnchor.width = visibleAnchor.right - visibleAnchor.left
-      visibleAnchor.height = visibleAnchor.bottom - visibleAnchor.top 
+      visibleAnchor.height = visibleAnchor.bottom - visibleAnchor.top
       return visibleAnchor;
     },
 
-    getHorizontallyCenteredLeft: function(movableRect, anchorRect, viewport) {
-      var visibleAnchor = this.anchorInsideViewport(anchorRect, viewport);
-      var left = visibleAnchor.left - ((movableRect.width - visibleAnchor.width) / 2);
+    getHorizontallyCenteredLeft: function(movableRect, anchorRect) {
+      var left = anchorRect.left - ((movableRect.width - anchorRect.width) / 2);
       left = Math.max(left, -1 * pageXOffset);
       return left;
     },
 
-    getVerticalCenteredTop: function(movableRect, anchorRect, viewport) {
-      var visibleAnchor = this.anchorInsideViewport(anchorRect, viewport);
-      var top = visibleAnchor.top - ((movableRect.height - visibleAnchor.height) / 2);
+    getVerticalCenteredTop: function(movableRect, anchorRect) {
+      var top = anchorRect.top - ((movableRect.height - anchorRect.height) / 2);
       top = Math.max(top, -1 * pageYOffset);
       return top;
     },
 
     getPosition: {
-      left: function(movableRect, anchorRect, viewport) {
+      left: function(movableRect, anchorRect) {
         return {
           left: anchorRect.left - movableRect.width,
           top: this.getVerticalCenteredTop.apply(this, arguments)
         }
       },
 
-      right: function(movableRect, anchorRect, viewport) {
+      right: function(movableRect, anchorRect) {
         return {
           left: anchorRect.right,
           top: this.getVerticalCenteredTop.apply(this, arguments)
         }
       },
 
-      top: function(movableRect, anchorRect, viewport) {
+      top: function(movableRect, anchorRect) {
         return {
           left: this.getHorizontallyCenteredLeft.apply(this, arguments),
           top: anchorRect.top - movableRect.height,
         };
       },
 
-      bottom: function(movableRect, anchorRect, viewport) {
+      bottom: function(movableRect, anchorRect) {
         return {
           left: this.getHorizontallyCenteredLeft.apply(this, arguments),
           top: anchorRect.bottom,

--- a/sticky.js
+++ b/sticky.js
@@ -66,25 +66,11 @@
       var anchorRect = this.getRectWithMargin(anchor);
       var anchorParent = anchor.parentElement;
 
-      // if the parent element is an svg tag,
-      // the svg viewport becomes the desired viewport,
-      // otherwise the viewport is the window.
-
-      if (anchorParent.tagName === "svg"){
-        var viewport = {
-          width: anchorParent.getBoundingClientRect().width,
-          height: anchorParent.getBoundingClientRect().height,     
-          top: anchorParent.getBoundingClientRect().top,     
-          left: anchorParent.getBoundingClientRect().left    
-        };
-      } else {
-        var viewport = {
-          width: innerWidth,
-          height: innerHeight,
-          top: 0,
-          left: 0
-        };
+      var current_node = anchor
+      while(current_node !== document.body && getComputedStyle(current_node).overflow !== 'hidden'){
+        current_node = current_node.parentNode;
       }
+      var viewport = current_node.getBoundingClientRect();
 
       var form = this.refs.form;
       form.style.left = '';

--- a/test/sticky.js
+++ b/test/sticky.js
@@ -84,25 +84,35 @@ describe('StickyModalForm', function() {
       });
 
       it('can stick to the bottom of the visible portion of a clipped SVG element', function() {
-
-        var instance = ReactDOM.render(
-          React.createElement( 'svg', { width:"100", height:"100", viewBox:"0 0 100 100", verticalAlign: "middle"},
-            React.createElement(StickyModalForm, { side: 'bottom'},
-              React.createElement('line', { x1:"-50", y1:"50", x2:"50", y2:"50", strokeWidth:"10"})
-            )
-          )
-        , root);
-
-        // is this the best way to access the node? can't pick up form refs...
-        var renderedSVGNode = ReactDOM.findDOMNode(instance);
-        var clickableGroupTag = renderedSVGNode.querySelector(".modal-form-trigger");
-
-        var svgRect = renderedSVGNode.getBoundingClientRect();
-
-
-        assert.equal(Math.round(svgRect.top), 100); 
-        assert.equal(Math.round(svgRect.left), 100);
+        var svg = document.createElementNS('http://www.w3.org/2000/svg','svg');
+        svg.setAttribute("width", "100");
+        svg.setAttribute("height", "100");
+        svg.setAttribute("viewBox", "0 0 100 100");
         
+        var line = document.createElementNS("http://www.w3.org/2000/svg", 'line');
+        line.setAttribute("x1", "-50");
+        line.setAttribute("y1", "50");
+        line.setAttribute("x2", "50");
+        line.setAttribute("y2", "50");
+        line.setAttribute("stroke-width", "10");
+        line.setAttribute("stroke", "5");
+
+        svg.appendChild(line);
+        root.appendChild(svg);
+        document.body.appendChild(root);
+
+        var instance = ReactDOM.render(React.createElement(StickyModalForm, {side: 'bottom'}, 'x'), line);
+        var instanceNode = ReactDOM.findDOMNode(instance);
+        simulant.fire(line, 'click');
+        var formPointer = instance.refs.pointer
+        
+        assert.equal(formPointer.getBoundingClientRect().top, 150);
+        assert.equal(formPointer.getBoundingClientRect().left, 125);
+
+        
+        ReactDOM.unmountComponentAtNode(line);
+        svg.parentNode.removeChild(svg);
+        svg = null;
       });
 
       afterEach(function() {

--- a/test/sticky.js
+++ b/test/sticky.js
@@ -83,6 +83,28 @@ describe('StickyModalForm', function() {
         assert.equal(formRect.top, 200);
       });
 
+      it('can stick to the bottom of the visible portion of a clipped SVG element', function() {
+
+        var instance = ReactDOM.render(
+          React.createElement( 'svg', { width:"100", height:"100", viewBox:"0 0 100 100", verticalAlign: "middle"},
+            React.createElement(StickyModalForm, { side: 'bottom'},
+              React.createElement('line', { x1:"-50", y1:"50", x2:"50", y2:"50", strokeWidth:"10"})
+            )
+          )
+        , root);
+
+        // is this the best way to access the node? can't pick up form refs...
+        var renderedSVGNode = ReactDOM.findDOMNode(instance);
+        var clickableGroupTag = renderedSVGNode.querySelector(".modal-form-trigger");
+
+        var svgRect = renderedSVGNode.getBoundingClientRect();
+
+
+        assert.equal(Math.round(svgRect.top), 100); 
+        assert.equal(Math.round(svgRect.left), 100);
+        
+      });
+
       afterEach(function() {
         content = null;
       });


### PR DESCRIPTION
This PR is meant to tackle Issue #17. This PR only addresses clipping caused by SVG viewports, which should fix some oddness we are seeing in the `/classify` page of PFE. In another PR, I do think we should address clipping caused by other custom viewports (e.g., by css clipping). 

**Test Suite Questions:**

-- Some of the `sticky.js` tests were failing before my changes due to rounding. Should we address this in the tests or the sticky.js component or both?
```
StickyModalForm :: instance :: `side` prop :: can stick to the left
100.00000762939453 == 100
```
-- I am having [trouble constructing a test ](https://github.com/zooniverse/modal-form/blob/svg-viewport-awareness/test/sticky.js#L86-L94) where I can access the position of a form created inside an `<svg>` tag. Suggestions on a better way to create this test?