### PR TITLE
more inclusive event detection

### DIFF
--- a/dialog.js
+++ b/dialog.js
@@ -14,7 +14,7 @@
     ModalFormBase = window.ZUIModalFormBase;
   }
 
-  var ModalDialog = React.createClass({
+  var ModalDialog = React.createClass({ 
     statics: {
       alert: function(message, props) {
         var container = document.createElement('div');

--- a/example.html
+++ b/example.html
@@ -18,6 +18,10 @@
         }
       }
 
+      svg {
+        overflow: hidden;
+      }
+
       .modal-form-underlay {
         animation: underlay-fade 0.5s;
         background: rgba(127, 127, 127, 0.2);

--- a/sticky.js
+++ b/sticky.js
@@ -58,7 +58,7 @@
     reposition: function(props) {
       ModalFormBase.prototype.reposition.apply(this, arguments);
 
-      if (props === undefined || props instanceof Event) {
+      if (props === undefined || props.currentTarget !== undefined) {
         props = this.props;
       }
 


### PR DESCRIPTION
This PR addresses the issue of the modal form moving to the top corner of the screen on scroll in IE11. 
To see the solution working in a PFE staged branch, look [here](https://traveling-modal-issue.pfe-preview.zooniverse.org). Thanks @brian-c for helping me troubleshoot and finding a solution!

Also, adds `overflow: hidden` to the svg elements in example.html.
