### PR TITLE
Use requestAnimationFrame to Delay Reposition

### DIFF
--- a/base.js
+++ b/base.js
@@ -88,6 +88,12 @@
       removeEventListener(ModalFormBase.locationChangeEvent, this.handleGlobalNavigation);
     },
 
+    componentDidUpdate: function() {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(this.reposition)
+      });
+    },
+
     handleGlobalKeyDown: function (event) {
       if (event.which === ESC_KEY && !this.props.required) {
         this.props.onCancel.apply(null, arguments);
@@ -141,10 +147,6 @@
     renderWithAnchor: function() {
       var looseRenderResult = this.renderLoose.apply(this, arguments);
       return React.createElement(ModalFormAnchor, null, looseRenderResult);
-    },
-
-    componentDidUpdate: function() {
-      this.reposition();
     },
 
     reposition: function() {


### PR DESCRIPTION
Fixes #[3249](https://github.com/zooniverse/Panoptes-Front-End/issues/3249) on PFE.

Tutorial modals weren't being repositioned correctly because the reposition code was firing before the children were finished updating. 