### PR TITLE
Use function syntax

### DIFF
--- a/.zuul.yml
+++ b/.zuul.yml
@@ -8,3 +8,5 @@ browsers:
     version: -1..latest
   - name: iphone
     version: -1..latest
+scripts:
+  - "requestAnimationFrame-polyfill.js"

--- a/base.js
+++ b/base.js
@@ -89,8 +89,8 @@
     },
 
     componentDidUpdate: function() {
-      requestAnimationFrame(() => {
-        requestAnimationFrame(this.reposition)
+      requestAnimationFrame(function() {
+        requestAnimationFrame(this.reposition);
       });
     },
 

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "zuul": "~3.5.0"
   },
   "scripts": {
-    "test": "zuul -- ./test/*.js",
-    "test-with-phantom": "zuul --phantom -- ./test/*.js",
+    "test": "zuul --phantom -- ./test/*.js",
     "serve-tests": "zuul --local 7357 -- ./test/*.js"
   }
 }

--- a/requestAnimationFrame-polyfill.js
+++ b/requestAnimationFrame-polyfill.js
@@ -1,0 +1,31 @@
+// http://paulirish.com/2011/requestanimationframe-for-smart-animating/
+// http://my.opera.com/emoller/blog/2011/12/20/requestanimationframe-for-smart-er-animating
+
+// requestAnimationFrame polyfill by Erik Möller. fixes from Paul Irish and Tino Zijdel
+
+// MIT license
+
+(function() {
+    var lastTime = 0;
+    var vendors = ['ms', 'moz', 'webkit', 'o'];
+    for(var x = 0; x < vendors.length && !window.requestAnimationFrame; ++x) {
+        window.requestAnimationFrame = window[vendors[x]+'RequestAnimationFrame'];
+        window.cancelAnimationFrame = window[vendors[x]+'CancelAnimationFrame'] 
+                                   || window[vendors[x]+'CancelRequestAnimationFrame'];
+    }
+ 
+    if (!window.requestAnimationFrame)
+        window.requestAnimationFrame = function(callback, element) {
+            var currTime = new Date().getTime();
+            var timeToCall = Math.max(0, 16 - (currTime - lastTime));
+            var id = window.setTimeout(function() { callback(currTime + timeToCall); }, 
+              timeToCall);
+            lastTime = currTime + timeToCall;
+            return id;
+        };
+ 
+    if (!window.cancelAnimationFrame)
+        window.cancelAnimationFrame = function(id) {
+            clearTimeout(id);
+        };
+}());


### PR DESCRIPTION
This is written in ES5 and so we should use that syntax. The arrow function is supported in most browsers now, but webpack was throwing a syntax error when transpiling for a staging deploy:

`SyntaxError: Unexpected token: punc ()) [./~/modal-form/base.js:92,0]`

