### PR TITLE
Only call reposition

### DIFF
--- a/base.js
+++ b/base.js
@@ -89,10 +89,7 @@
     },
 
     componentDidUpdate: function() {
-      var that = this;
-      requestAnimationFrame(function() {
-        requestAnimationFrame(that.reposition);
-      });
+      this.reposition();
     },
 
     handleGlobalKeyDown: function (event) {

--- a/base.js
+++ b/base.js
@@ -89,8 +89,9 @@
     },
 
     componentDidUpdate: function() {
+      var that = this;
       requestAnimationFrame(function() {
-        requestAnimationFrame(this.reposition);
+        requestAnimationFrame(that.reposition);
       });
     },
 


### PR DESCRIPTION
So that failing test in #25 is actually breaking functionality in the browser and isn't just an issue in phantom.js. Reverting back to the behavior prior to adding `requestAnimationFrame` since there were issues with binding this when using function syntax and use of the arrow function broke deploys with webpack. A bit more time will need to be spent on it.