### PR TITLE
Use requestAnimationFrame to delay reposition

### DIFF
--- a/base.js
+++ b/base.js
@@ -66,6 +66,7 @@
         // Mounting a modal with `autoFocus` content scrolls to the top before it repositions.
         this._originalScrollPosition = [pageXOffset, pageYOffset];
       }
+      this.reposition = this.reposition.bind(this);
     },
 
     componentDidMount: function() {
@@ -89,7 +90,10 @@
     },
 
     componentDidUpdate: function() {
-      this.reposition();
+      var reposition = this.reposition;
+      requestAnimationFrame(function(){
+        requestAnimationFrame(reposition);
+      });
     },
 
     handleGlobalKeyDown: function (event) {
@@ -148,19 +152,21 @@
     },
 
     reposition: function() {
-      var formRect = this.refs.form.getBoundingClientRect();
-      var formStyle = getComputedStyle(this.refs.form);
-      var formRight = pageXOffset + formRect.right + parseFloat(formStyle.marginRight);
-      var formBottom = pageYOffset + formRect.bottom + parseFloat(formStyle.marginBottom);
-      var totalWidth = Math.max(document.documentElement.offsetWidth, formRight); // Skip `innerWidth` to avoid counting scrollbar.
-      var totalHeight = Math.max(document.documentElement.offsetHeight, innerHeight, formBottom);
-      if (totalWidth !== this.state.underlayWidth || totalHeight !== this.state.underlayHeight) {
-        this.setState({
-          underlayWidth: totalWidth,
-          underlayHeight: totalHeight
-        });
+      if (this.refs && this.refs.form) {
+        var formRect = this.refs.form.getBoundingClientRect();
+        var formStyle = getComputedStyle(this.refs.form);
+        var formRight = pageXOffset + formRect.right + parseFloat(formStyle.marginRight);
+        var formBottom = pageYOffset + formRect.bottom + parseFloat(formStyle.marginBottom);
+        var totalWidth = Math.max(document.documentElement.offsetWidth, formRight); // Skip `innerWidth` to avoid counting scrollbar.
+        var totalHeight = Math.max(document.documentElement.offsetHeight, innerHeight, formBottom);
+        if (totalWidth !== this.state.underlayWidth || totalHeight !== this.state.underlayHeight) {
+          this.setState({
+            underlayWidth: totalWidth,
+            underlayHeight: totalHeight
+          });
+        }
+        this.props.onReposition();
       }
-      this.props.onReposition();
     },
 
     handleFormSubmit: function(event) {

--- a/dialog.js
+++ b/dialog.js
@@ -114,8 +114,8 @@
         var top = this.state.scrollY + Math.max(0, vertical - (this.props.top * form.offsetHeight));
         if (left !== this.state.dialogLeft || top !== this.state.dialogTop) {
           this.setState({
-            dialogLeft: left,
-            dialogTop: top
+            dialogLeft: parseInt(left),
+            dialogTop: parseInt(top)
           });
         }
       }

--- a/dialog.js
+++ b/dialog.js
@@ -68,8 +68,8 @@
       return {
         scrollX: pageXOffset,
         scrollY: pageYOffset,
-        dialogLeft: 0,
-        dialogTop: 0
+        dialogLeft: -1000,
+        dialogTop: -1000
       };
     },
 

--- a/sticky.js
+++ b/sticky.js
@@ -55,12 +55,8 @@
       }, this);
     },
 
-    reposition: function(props) {
+    reposition: function() {
       ModalFormBase.prototype.reposition.apply(this, arguments);
-
-      if (props === undefined || props.currentTarget !== undefined) {
-        props = this.props;
-      }
 
       var anchor = ReactDOM.findDOMNode(this).parentNode;
       var anchorRect = this.getRectWithMargin(anchor);
@@ -77,7 +73,7 @@
       form.style.left = '';
       form.style.top = '';
       var formRect = this.getRectWithMargin(form);
-      var formPosition = this.getPosition[props.side].call(this, formRect, visibleAnchorRect);
+      var formPosition = this.getPosition[this.props.side].call(this, formRect, visibleAnchorRect);
       form.style.left = pageXOffset + formPosition.left + 'px';
       form.style.top = pageYOffset + formPosition.top + 'px';
 
@@ -85,7 +81,7 @@
       pointer.style.left = '';
       pointer.style.top = '';
       var pointerRect = this.getRectWithMargin(pointer);
-      var pointerPosition = this.getPosition[props.side].call(this, pointerRect, visibleAnchorRect);
+      var pointerPosition = this.getPosition[this.props.side].call(this, pointerRect, visibleAnchorRect);
       pointer.style.left = pageXOffset + pointerPosition.left + 'px';
       pointer.style.top = pageYOffset + pointerPosition.top + 'px';
     },

--- a/sticky.js
+++ b/sticky.js
@@ -74,8 +74,8 @@
       form.style.top = '';
       var formRect = this.getRectWithMargin(form);
       var formPosition = this.getPosition[this.props.side].call(this, formRect, visibleAnchorRect);
-      form.style.left = pageXOffset + formPosition.left + 'px';
-      form.style.top = pageYOffset + formPosition.top + 'px';
+      form.style.left = parseInt(pageXOffset + formPosition.left) + 'px';
+      form.style.top = parseInt(pageYOffset + formPosition.top) + 'px';
 
       var pointer = this.refs.pointer;
       pointer.style.left = '';


### PR DESCRIPTION
Check for `this.refs.form` before recalculating dimensions.

Fixes zooniverse/Panoptes-Front-End#3249