### PR TITLE
Add anchored forms to DOM before rendering

### DIFF
--- a/anchor.js
+++ b/anchor.js
@@ -19,9 +19,6 @@
     componentWillMount: function() {
       this.root = document.createElement('div');
       this.root.classList.add('modal-form-anchor-root');
-    },
-
-    componentDidMount: function() {
       document.body.appendChild(this.root);
     },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "modal-form",
-  "version": "2.5.3",
+  "version": "2.6.1-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modal-form",
-  "version": "2.6.0",
+  "version": "2.6.1-0",
   "devDependencies": {
     "babel-core": "~5.8.38",
     "core-js": "~2.4.0",


### PR DESCRIPTION
Add anchored forms to the DOM in componentWillMount, rather than waiting until after rendering. Otherwise, autofocus is broken in rendered children.